### PR TITLE
RHCLOUD-46706 - Implement principal from RH identity helpers

### DIFF
--- a/.cursor/skills/release-node-sdk/SKILL.md
+++ b/.cursor/skills/release-node-sdk/SKILL.md
@@ -58,6 +58,7 @@ npm install
 ```bash
 npm test
 npm run lint
+npm run prettier:check
 npm run build
 ```
 
@@ -130,7 +131,7 @@ Release v${VERSION}:
 - [ ] Update package.json version
 - [ ] Set VERSION env var
 - [ ] Update dependencies (npm install)
-- [ ] Run npm test, npm run lint, npm run build
+- [ ] Run npm test, npm run lint, npm run prettier:check, npm run build
 - [ ] Review changes and confirm with user before committing
 - [ ] Commit and push version bump
 - [ ] Publish to npm (npm publish)

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ npm test
 # Run linting
 npm run lint
 
+# Check formatting
+npm run prettier:check
 
 # Build the project
 npm run build

--- a/README.md
+++ b/README.md
@@ -115,11 +115,53 @@ new ClientBuilder(target)
 
 ## Examples
 
-Check out the [examples directory](./examples) for working code samples:
+Check out the [examples directory](./examples) for working code samples. Scripts are defined in [`examples/package.json`](./examples/package.json).
 
-- **[Builder examples](./examples/builder/)** -- Modern async/await patterns with `ClientBuilder` (check, check_bulk, report, delete, streaming)
-- **[Vanilla examples](./examples/vanilla/)** -- Traditional callback patterns using raw gRPC stubs
-- **[RBAC examples](./examples/rbac/)** -- Workspace operations via REST API
+- **[Builder examples](./examples/builder/)**: Modern async/await patterns with the client builder API
+- **[Vanilla examples](./examples/vanilla/)**: Traditional callback-style patterns
+- **[Authentication examples](./examples/builder/auth.ts)**: OAuth 2.0 client credentials setup and usage
+- **[Streaming examples](./examples/builder/streamed_list_objects.ts)**: Working with streaming APIs
+- **[RBAC examples](./examples/rbac/)**: Workspace listing and fetching
+- **[Console examples](./examples/console/)**: Red Hat identity principal helpers
+
+### Setup
+
+```bash
+cd examples
+npm install
+```
+
+### Running Examples
+
+```bash
+# Builder-style examples (async/await)
+npm run builder:check
+npm run builder:check_bulk
+npm run builder:check_for_update
+npm run builder:report_resource
+npm run builder:delete_resource
+npm run builder:streamed_list_objects
+npm run builder:auth
+
+# Vanilla examples (callback-style)
+npm run vanilla:check
+npm run vanilla:check_bulk
+npm run vanilla:check_for_update
+npm run vanilla:report_resource
+npm run vanilla:delete_resource
+npm run vanilla:streamed_list_objects
+npm run vanilla:promisify
+npm run vanilla:auth
+
+# RBAC examples
+npm run rbac:list_workspaces
+npm run rbac:fetch_workspace
+
+# Console examples
+npm run console:console_principal
+```
+
+> **Note:** If you've made changes to the SDK source, run `npm run build` in the root directory before running examples, as the examples reference the local build.
 
 ## Project Structure
 

--- a/examples/console/console_principal.ts
+++ b/examples/console/console_principal.ts
@@ -3,7 +3,6 @@ import {
   principalFromRHIdentityHeader,
 } from "@project-kessel/kessel-sdk/kessel/console";
 
-
 // --- From a parsed User identity object ---
 const userIdentity = {
   type: "User",

--- a/examples/console/console_principal.ts
+++ b/examples/console/console_principal.ts
@@ -1,0 +1,42 @@
+import {
+  principalFromRHIdentity,
+  principalFromRHIdentityHeader,
+} from "@project-kessel/kessel-sdk/kessel/console";
+
+
+// --- From a parsed User identity object ---
+const userIdentity = {
+  type: "User",
+  org_id: "12345",
+  user: { user_id: "7393748", username: "jdoe" },
+};
+
+let subject = principalFromRHIdentity(userIdentity);
+console.log(`User principal:            ${subject.resource?.resourceId}`);
+
+// --- From a parsed ServiceAccount identity object ---
+const saIdentity = {
+  type: "ServiceAccount",
+  org_id: "456",
+  service_account: {
+    user_id: "12345",
+    client_id: "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+    username: "service-account-b69eaf9e",
+  },
+};
+
+subject = principalFromRHIdentity(saIdentity);
+console.log(`ServiceAccount principal:  ${subject.resource?.resourceId}`);
+
+// --- From a raw base64-encoded x-rh-identity header ---
+const headerPayload = {
+  identity: {
+    type: "User",
+    org_id: "12345",
+    user: { user_id: "7393748", username: "jdoe" },
+  },
+};
+
+const header = Buffer.from(JSON.stringify(headerPayload)).toString("base64");
+subject = principalFromRHIdentityHeader(header);
+console.log(`From header principal:     ${subject.resource?.resourceId}`);

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,6 +19,7 @@
     "builder:auth": "tsx builder/auth.ts",
     "rbac:fetch_workspace": "tsx rbac/fetch_workspace.ts",
     "rbac:list_workspaces": "tsx rbac/list_workspaces.ts",
+    "console:console_principal": "tsx console/console_principal.ts",
     "postinstall": "tsx setup.ts"
   },
   "author": "Josejulio Martínez",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/esm/kessel/auth/*.js",
       "types": "./dist/types/kessel/auth/*.d.ts"
     },
+    "./kessel/console": {
+      "require": "./dist/cjs/kessel/console/index.js",
+      "import": "./dist/esm/kessel/console/index.js",
+      "types": "./dist/types/kessel/console/index.d.ts"
+    },
     "./kessel/rbac/v2": {
       "require": "./dist/cjs/kessel/rbac/v2.js",
       "import": "./dist/esm/kessel/rbac/v2.js",
@@ -68,7 +73,8 @@
     "prettier:base": "prettier src/** *.json ./*js README.md examples/** tsc-alias-replacers/**",
     "lint": "eslint --fix src examples",
     "lint:check": "eslint src examples",
-    "test": "jest"
+    "test": "jest",
+    "type-check": "tsc --noEmit"
   },
   "files": [
     "package.json",

--- a/src/kessel/console/__tests__/index.ts
+++ b/src/kessel/console/__tests__/index.ts
@@ -1,7 +1,4 @@
-import {
-  principalFromRHIdentity,
-  principalFromRHIdentityHeader,
-} from "..";
+import { principalFromRHIdentity, principalFromRHIdentityHeader } from "..";
 
 function encodeHeader(payload: Record<string, unknown>): string {
   return Buffer.from(JSON.stringify(payload)).toString("base64");
@@ -167,9 +164,9 @@ describe("principalFromRHIdentityHeader", () => {
   });
 
   it("throws for malformed base64", () => {
-    expect(() =>
-      principalFromRHIdentityHeader("not-valid-base64!!!"),
-    ).toThrow(/Failed to decode identity header/);
+    expect(() => principalFromRHIdentityHeader("not-valid-base64!!!")).toThrow(
+      /Failed to decode identity header/,
+    );
   });
 
   it("throws for invalid JSON", () => {

--- a/src/kessel/console/__tests__/index.ts
+++ b/src/kessel/console/__tests__/index.ts
@@ -1,0 +1,248 @@
+import {
+  principalFromRHIdentity,
+  principalFromRHIdentityHeader,
+} from "..";
+
+function encodeHeader(payload: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64");
+}
+
+describe("principalFromRHIdentity", () => {
+  it("resolves User identity", () => {
+    const identity = {
+      type: "User",
+      org_id: "1979710",
+      user: { user_id: "7393748", username: "foobar" },
+    };
+    const ref = principalFromRHIdentity(identity);
+    expect(ref.resource?.resourceType).toBe("principal");
+    expect(ref.resource?.resourceId).toBe("redhat/7393748");
+    expect(ref.resource?.reporter?.type).toBe("rbac");
+    expect(ref.relation).toBeUndefined();
+  });
+
+  it("resolves ServiceAccount identity", () => {
+    const identity = {
+      type: "ServiceAccount",
+      org_id: "456",
+      service_account: {
+        user_id: "sa-456",
+        client_id: "b69eaf9e",
+        username: "svc-b69eaf9e",
+      },
+    };
+    const ref = principalFromRHIdentity(identity);
+    expect(ref.resource?.resourceId).toBe("redhat/sa-456");
+  });
+
+  it("uses custom domain", () => {
+    const identity = {
+      type: "User",
+      user: { user_id: "42" },
+    };
+    const ref = principalFromRHIdentity(identity, "custom");
+    expect(ref.resource?.resourceId).toBe("custom/42");
+  });
+
+  it("throws for unsupported identity type", () => {
+    const identity = { type: "System" };
+    expect(() => principalFromRHIdentity(identity)).toThrow(
+      /Unsupported identity type/,
+    );
+  });
+
+  it("throws for missing type field", () => {
+    const identity = { org_id: "123" } as any;
+    expect(() => principalFromRHIdentity(identity)).toThrow(
+      /Unsupported identity type/,
+    );
+  });
+
+  it("throws for missing user details", () => {
+    const identity = { type: "User" };
+    expect(() => principalFromRHIdentity(identity)).toThrow(
+      /missing the "user" field/,
+    );
+  });
+
+  it("throws for missing service_account details", () => {
+    const identity = { type: "ServiceAccount" };
+    expect(() => principalFromRHIdentity(identity)).toThrow(
+      /missing the "service_account" field/,
+    );
+  });
+
+  it("throws for missing user_id in User", () => {
+    const identity = {
+      type: "User",
+      user: { username: "foobar" },
+    };
+    expect(() => principalFromRHIdentity(identity)).toThrow(
+      /Unable to resolve user ID/,
+    );
+  });
+
+  it("throws for empty user_id in User", () => {
+    const identity = {
+      type: "User",
+      user: { user_id: "" },
+    };
+    expect(() => principalFromRHIdentity(identity)).toThrow(
+      /Unable to resolve user ID/,
+    );
+  });
+
+  it("throws for missing user_id in ServiceAccount", () => {
+    const identity = {
+      type: "ServiceAccount",
+      service_account: { client_id: "b69eaf9e" },
+    };
+    expect(() => principalFromRHIdentity(identity)).toThrow(
+      /Unable to resolve user ID/,
+    );
+  });
+
+  it("throws when user field is not a map", () => {
+    const identity = { type: "User", user: "not-a-map" };
+    expect(() => principalFromRHIdentity(identity)).toThrow(
+      /missing the "user" field/,
+    );
+  });
+
+  it("throws for null identity", () => {
+    expect(() => principalFromRHIdentity(null as any)).toThrow(
+      /identity must be an object/,
+    );
+  });
+
+  it("throws for string identity", () => {
+    expect(() => principalFromRHIdentity("not-an-object" as any)).toThrow(
+      /identity must be an object/,
+    );
+  });
+});
+
+describe("principalFromRHIdentityHeader", () => {
+  it("decodes valid User header", () => {
+    const header = encodeHeader({
+      identity: {
+        type: "User",
+        org_id: "1979710",
+        user: { user_id: "7393748", username: "foobar" },
+      },
+    });
+    const ref = principalFromRHIdentityHeader(header);
+    expect(ref.resource?.resourceId).toBe("redhat/7393748");
+    expect(ref.resource?.resourceType).toBe("principal");
+  });
+
+  it("decodes valid ServiceAccount header", () => {
+    const header = encodeHeader({
+      identity: {
+        type: "ServiceAccount",
+        org_id: "456",
+        service_account: { user_id: "sa-789", client_id: "b69eaf9e" },
+      },
+    });
+    const ref = principalFromRHIdentityHeader(header);
+    expect(ref.resource?.resourceId).toBe("redhat/sa-789");
+  });
+
+  it("uses custom domain", () => {
+    const header = encodeHeader({
+      identity: { type: "User", user: { user_id: "1" } },
+    });
+    const ref = principalFromRHIdentityHeader(header, "acme");
+    expect(ref.resource?.resourceId).toBe("acme/1");
+  });
+
+  it("throws for missing identity envelope", () => {
+    const header = encodeHeader({
+      type: "User",
+      user: { user_id: "42" },
+    });
+    expect(() => principalFromRHIdentityHeader(header)).toThrow(
+      /missing the "identity" envelope key/,
+    );
+  });
+
+  it("throws for malformed base64", () => {
+    expect(() =>
+      principalFromRHIdentityHeader("not-valid-base64!!!"),
+    ).toThrow(/Failed to decode identity header/);
+  });
+
+  it("throws for invalid JSON", () => {
+    const header = Buffer.from("this is not json").toString("base64");
+    expect(() => principalFromRHIdentityHeader(header)).toThrow(
+      /Failed to decode identity header/,
+    );
+  });
+
+  it("throws for unsupported type in header", () => {
+    const header = encodeHeader({
+      identity: { type: "System" },
+    });
+    expect(() => principalFromRHIdentityHeader(header)).toThrow(
+      /Unsupported identity type/,
+    );
+  });
+
+  it("decodes realistic User header", () => {
+    const header = encodeHeader({
+      identity: {
+        account_number: "540155",
+        org_id: "1979710",
+        user: {
+          username: "rhn-support-foobar",
+          is_internal: true,
+          is_org_admin: true,
+          first_name: "foo",
+          last_name: "bar",
+          is_active: true,
+          user_id: "7393748",
+          email: "example@redhat.com",
+        },
+        type: "User",
+      },
+    });
+    const ref = principalFromRHIdentityHeader(header);
+    expect(ref.resource?.resourceId).toBe("redhat/7393748");
+    expect(ref.resource?.resourceType).toBe("principal");
+    expect(ref.resource?.reporter?.type).toBe("rbac");
+  });
+
+  it("decodes realistic ServiceAccount header", () => {
+    const header = encodeHeader({
+      identity: {
+        org_id: "456",
+        type: "ServiceAccount",
+        service_account: {
+          user_id: "sa-b69eaf9e",
+          client_id: "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+          username: "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+        },
+      },
+    });
+    const ref = principalFromRHIdentityHeader(header);
+    expect(ref.resource?.resourceId).toBe("redhat/sa-b69eaf9e");
+  });
+
+  it("populates all subject fields from header", () => {
+    const header = encodeHeader({
+      identity: {
+        type: "ServiceAccount",
+        org_id: "org-1",
+        service_account: {
+          user_id: "sa-999",
+          username: "service-account-sa-999",
+        },
+      },
+    });
+    const ref = principalFromRHIdentityHeader(header);
+    expect(ref.resource?.resourceType).toBe("principal");
+    expect(ref.resource?.resourceId).toBe("redhat/sa-999");
+    expect(ref.resource?.reporter?.type).toBe("rbac");
+    expect(ref.relation).toBeUndefined();
+  });
+});

--- a/src/kessel/console/index.ts
+++ b/src/kessel/console/index.ts
@@ -70,9 +70,7 @@ export const principalFromRHIdentityHeader = (
 
   const identity = decoded.identity as Record<string, unknown> | undefined;
   if (identity == null) {
-    throw new Error(
-      'Identity header is missing the "identity" envelope key',
-    );
+    throw new Error('Identity header is missing the "identity" envelope key');
   }
 
   return principalFromRHIdentity(identity, domain);

--- a/src/kessel/console/index.ts
+++ b/src/kessel/console/index.ts
@@ -1,0 +1,79 @@
+import { SubjectReference } from "../inventory/v1beta2/subject_reference";
+import { principalSubject } from "../rbac/v2";
+
+const DEFAULT_DOMAIN = "redhat";
+
+const IDENTITY_TYPE_FIELDS: Record<string, string> = {
+  User: "user",
+  ServiceAccount: "service_account",
+};
+
+function extractUserID(
+  identity: Record<string, unknown> | null | undefined,
+): string {
+  if (identity == null || typeof identity !== "object") {
+    throw new Error("identity must be an object");
+  }
+
+  const identityType = identity.type as string | undefined;
+  const field = identityType ? IDENTITY_TYPE_FIELDS[identityType] : undefined;
+
+  if (!field) {
+    const supported = Object.keys(IDENTITY_TYPE_FIELDS).sort().join(", ");
+    throw new Error(
+      `Unsupported identity type: "${identityType}" (supported: ${supported})`,
+    );
+  }
+
+  const details = identity[field];
+  if (details == null || typeof details !== "object") {
+    throw new Error(
+      `Identity type "${identityType}" is missing the "${field}" field`,
+    );
+  }
+
+  const userId = (details as Record<string, unknown>).user_id;
+  if (!userId || typeof userId !== "string") {
+    throw new Error(
+      `Unable to resolve user ID from ${identityType} identity (tried: user_id)`,
+    );
+  }
+
+  return userId;
+}
+
+export const principalFromRHIdentity = (
+  identity: Record<string, unknown>,
+  domain: string = DEFAULT_DOMAIN,
+): SubjectReference => {
+  const userId = extractUserID(identity);
+  return principalSubject(userId, domain);
+};
+
+export const principalFromRHIdentityHeader = (
+  header: string,
+  domain: string = DEFAULT_DOMAIN,
+): SubjectReference => {
+  let decoded: Record<string, unknown>;
+  try {
+    const json = Buffer.from(header, "base64").toString("utf-8");
+    decoded = JSON.parse(json);
+  } catch (e) {
+    throw new Error(
+      `Failed to decode identity header: ${e instanceof Error ? e.message : e}`,
+    );
+  }
+
+  if (decoded == null || typeof decoded !== "object") {
+    throw new Error("Identity header did not decode to a JSON object");
+  }
+
+  const identity = decoded.identity as Record<string, unknown> | undefined;
+  if (identity == null) {
+    throw new Error(
+      'Identity header is missing the "identity" envelope key',
+    );
+  }
+
+  return principalFromRHIdentity(identity, domain);
+};


### PR DESCRIPTION
Adds `principalFromRHIdentity()` and `principalFromRHIdentityHeader()` to new Console pkg, enabling consumers to build principal SubjectReferences directly from platform identity dicts or raw x-rh-identity headers.


https://redhat.atlassian.net/browse/RHCLOUD-46706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a console entry that converts Red Hat identity inputs into principal references and a runnable example demonstrating multiple identity formats.

* **Documentation**
  * Expanded README with setup/running examples, path-specific example links, build note for local SDK changes, and a Formatting check step.

* **Tests**
  * Added comprehensive tests covering identity conversion, header decoding, and error cases.

* **Chores**
  * Release quality checks updated to include a formatting verification; added a package script for type-checking and an examples run script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->