### PR TITLE
chore: bump version to 3.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-kessel/kessel-sdk",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-kessel/kessel-sdk",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-kessel/kessel-sdk",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "This is the official Node.js SDK for [Project Kessel](https://github.com/project-kessel), a system for unifying APIs and experiences with fine-grained authorization, common inventory, and CloudEvents.",
   "type": "module",
   "exports": {

--- a/src/google/api/annotations.ts
+++ b/src/google/api/annotations.ts
@@ -4,7 +4,6 @@
 //   protoc               unknown
 // source: google/api/annotations.proto
 
-/* eslint-disable */
 import _m0 from "protobufjs/minimal";
 import { HttpRule } from "./http";
 

--- a/src/kessel/inventory/v1beta2/inventory_service.ts
+++ b/src/kessel/inventory/v1beta2/inventory_service.ts
@@ -4,7 +4,6 @@
 //   protoc               unknown
 // source: kessel/inventory/v1beta2/inventory_service.proto
 
-/* eslint-disable */
 import {
   type CallOptions,
   ChannelCredentials,


### PR DESCRIPTION
## Summary

- Bump version to 3.7.0 (minor release)
- Fix Prettier formatting in two generated files (`src/google/api/annotations.ts`, `src/kessel/inventory/v1beta2/inventory_service.ts`)

## What's in this release (since v3.6.0)

- **New `kessel/console` module** — `principalFromIdentity` and `principalFromXRHIdentityHeader` helpers for building `SubjectReference` from Red Hat Console identity objects (RHCLOUD-46706, #44)
- **New protobuf types** — `StreamedListSubjectsRequest` / `StreamedListSubjectsResponse` from upstream buf regeneration (#43)
- **New package export** — `./kessel/console` subpath (CJS + ESM + types)
- **Documentation** — AGENTS.md, CLAUDE.md, `docs/` guidelines, expanded README (#45)

## Test plan

- [x] `npm test` — 135 tests passing across 5 suites
- [x] `npm run lint` — clean
- [x] `npm run prettier:check` — clean
- [x] `npm run build` — CJS + ESM + types all build successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 3.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->