### PR TITLE
RHCLOUD-47742 - Update locking mechanism for concurrent token refreshes

### DIFF
--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -37,7 +37,7 @@ Rules:
 - Do not call `getToken(true)` (force refresh) unless handling a 401/UNAUTHENTICATED error.
 - The `oauth4webapi` dependency is lazy-loaded via `import()` on first use, so construction is cheap.
 
-**Concurrent request hazard:** There is no deduplication of in-flight token refreshes. If the cache expires and 50 RPCs fire simultaneously, up to 50 token requests may hit the OAuth server. For high-concurrency services, consider wrapping `getToken()` or adding your own single-flight logic.
+**Concurrent refresh coalescing:** `getToken()` uses Promise coalescing (single-flight) to deduplicate in-flight token refreshes. If the cache expires and 50 RPCs fire simultaneously, only one token request is made to the OAuth server; the other 49 callers await the same in-flight Promise and receive the result when it resolves. This applies to both normal and `forceRefresh` calls. If the in-flight refresh fails, all coalesced callers receive the error and subsequent calls will retry.
 
 ## 4. Use Bulk APIs Instead of Parallel Individual Checks
 

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -22,6 +22,9 @@ The `oauth4webapi` package is listed under `optionalDependencies`. It is loaded 
 ### Token caching and expiration window
 `OAuth2ClientCredentials` caches tokens internally and considers them invalid 5 minutes before actual expiry (`EXPIRATION_WINDOW_MILLI = 300000`). When `expires_in` is missing from the OAuth response, it defaults to 1 hour (`DEFAULT_EXPIRE_IN_SECONDS = 3600`). The cached token response object is frozen with `Object.freeze`. Do not attempt to mutate it.
 
+### Concurrent refresh safety
+`getToken()` uses Promise coalescing to prevent thundering herd token refreshes. When multiple concurrent callers observe a stale token, only one OAuth request is made; the others await the same in-flight Promise. This is safe for both normal and `forceRefresh` calls. Errors from the single refresh propagate to all coalesced callers, and subsequent calls will retry normally.
+
 ### Force-refresh support
 Call `getToken(true)` to bypass the cache and force a fresh token. Use this only for error recovery (e.g., after a 401 from the server), not routinely.
 

--- a/src/kessel/auth/__tests__/index.ts
+++ b/src/kessel/auth/__tests__/index.ts
@@ -585,6 +585,32 @@ describe("OAuth2ClientCredentials", () => {
       tokens.forEach((t) => expect(t.accessToken).toBe("second-token"));
       expect(callCount).toBe(2);
     });
+
+    it("cold-start with short-lived token triggers exactly 1 SSO call", async () => {
+      const tokenRetriever = new OAuth2ClientCredentials(mockAuth);
+
+      let callCount = 0;
+      mockOAuth.ClientSecretPost.mockReturnValue("mock-client-auth");
+      mockOAuth.clientCredentialsGrantRequest.mockImplementation(async () => {
+        callCount++;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return {};
+      });
+      mockOAuth.processClientCredentialsResponse.mockResolvedValue({
+        access_token: "short-lived-token",
+        expires_in: 60,
+      });
+
+      const promises = Array.from({ length: 20 }, () =>
+        tokenRetriever.getToken(),
+      );
+      const tokens = await Promise.all(promises);
+
+      tokens.forEach((token) =>
+        expect(token.accessToken).toBe("short-lived-token"),
+      );
+      expect(callCount).toBe(1);
+    });
   });
 
   describe("Configuration Edge Cases", () => {

--- a/src/kessel/auth/__tests__/index.ts
+++ b/src/kessel/auth/__tests__/index.ts
@@ -439,6 +439,154 @@ describe("OAuth2ClientCredentials", () => {
     });
   });
 
+  describe("Thundering Herd", () => {
+    it("concurrent stale-token refreshes result in exactly 1 SSO call", async () => {
+      const tokenRetriever = new OAuth2ClientCredentials(mockAuth);
+
+      // Pre-seed a token inside the 300s early-refresh window
+      (tokenRetriever as any).tokenCache = {
+        accessToken: "stale-token",
+        expiresAt: new Date(Date.now() + 60000), // 60s remaining
+      };
+
+      let callCount = 0;
+      mockOAuth.ClientSecretPost.mockReturnValue("mock-client-auth");
+      mockOAuth.clientCredentialsGrantRequest.mockImplementation(async () => {
+        callCount++;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return {};
+      });
+      mockOAuth.processClientCredentialsResponse.mockResolvedValue({
+        access_token: "refreshed-token",
+        expires_in: 3600,
+      });
+
+      const promises = Array.from({ length: 20 }, () =>
+        tokenRetriever.getToken(),
+      );
+      const tokens = await Promise.all(promises);
+
+      tokens.forEach((token) =>
+        expect(token.accessToken).toBe("refreshed-token"),
+      );
+      expect(callCount).toBe(1);
+    });
+
+    it("concurrent force-refresh calls result in exactly 1 SSO call", async () => {
+      const tokenRetriever = new OAuth2ClientCredentials(mockAuth);
+
+      // Pre-seed a valid token so force-refresh is the only trigger
+      (tokenRetriever as any).tokenCache = {
+        accessToken: "valid-token",
+        expiresAt: new Date(Date.now() + 3600000),
+      };
+
+      let callCount = 0;
+      mockOAuth.ClientSecretPost.mockReturnValue("mock-client-auth");
+      mockOAuth.clientCredentialsGrantRequest.mockImplementation(async () => {
+        callCount++;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return {};
+      });
+      mockOAuth.processClientCredentialsResponse.mockResolvedValue({
+        access_token: "force-refreshed-token",
+        expires_in: 3600,
+      });
+
+      const promises = Array.from({ length: 20 }, () =>
+        tokenRetriever.getToken(true),
+      );
+      const tokens = await Promise.all(promises);
+
+      tokens.forEach((token) =>
+        expect(token.accessToken).toBe("force-refreshed-token"),
+      );
+      expect(callCount).toBe(1);
+    });
+
+    it("propagates refresh errors to all coalesced callers", async () => {
+      const tokenRetriever = new OAuth2ClientCredentials(mockAuth);
+
+      mockOAuth.ClientSecretPost.mockReturnValue("mock-client-auth");
+      mockOAuth.clientCredentialsGrantRequest.mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        throw new Error("SSO unavailable");
+      });
+
+      const promises = Array.from({ length: 5 }, () =>
+        tokenRetriever.getToken(),
+      );
+      const results = await Promise.allSettled(promises);
+
+      const rejected = results.filter(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
+      );
+      expect(rejected).toHaveLength(5);
+      rejected.forEach((r) => expect(r.reason.message).toBe("SSO unavailable"));
+
+      expect(mockOAuth.clientCredentialsGrantRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows retry after a failed coalesced refresh", async () => {
+      const tokenRetriever = new OAuth2ClientCredentials(mockAuth);
+
+      mockOAuth.ClientSecretPost.mockReturnValue("mock-client-auth");
+      mockOAuth.clientCredentialsGrantRequest
+        .mockRejectedValueOnce(new Error("SSO unavailable"))
+        .mockResolvedValueOnce({});
+      mockOAuth.processClientCredentialsResponse.mockResolvedValue({
+        access_token: "retry-token",
+        expires_in: 3600,
+      });
+
+      await expect(tokenRetriever.getToken()).rejects.toThrow(
+        "SSO unavailable",
+      );
+
+      const token = await tokenRetriever.getToken();
+      expect(token.accessToken).toBe("retry-token");
+    });
+
+    it("refreshes again after a previous coalesced refresh expires", async () => {
+      const tokenRetriever = new OAuth2ClientCredentials(mockAuth);
+
+      let callCount = 0;
+      mockOAuth.ClientSecretPost.mockReturnValue("mock-client-auth");
+      mockOAuth.clientCredentialsGrantRequest.mockImplementation(async () => {
+        callCount++;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return {};
+      });
+      mockOAuth.processClientCredentialsResponse.mockResolvedValue({
+        access_token: "first-token",
+        expires_in: 3600,
+      });
+
+      // First batch: cold start, should make 1 SSO call
+      const batch1 = Array.from({ length: 5 }, () => tokenRetriever.getToken());
+      await Promise.all(batch1);
+      expect(callCount).toBe(1);
+
+      // Expire the token
+      (tokenRetriever as any).tokenCache = {
+        accessToken: "first-token",
+        expiresAt: new Date(Date.now() - 1000),
+      };
+
+      mockOAuth.processClientCredentialsResponse.mockResolvedValue({
+        access_token: "second-token",
+        expires_in: 3600,
+      });
+
+      // Second batch: expired token, should make exactly 1 more SSO call
+      const batch2 = Array.from({ length: 5 }, () => tokenRetriever.getToken());
+      const tokens = await Promise.all(batch2);
+
+      tokens.forEach((t) => expect(t.accessToken).toBe("second-token"));
+      expect(callCount).toBe(2);
+    });
+  });
+
   describe("Configuration Edge Cases", () => {
     it("handles empty client ID", () => {
       const authWithEmptyClientId = {

--- a/src/kessel/auth/__tests__/index.ts
+++ b/src/kessel/auth/__tests__/index.ts
@@ -504,7 +504,7 @@ describe("OAuth2ClientCredentials", () => {
       expect(callCount).toBe(1);
     });
 
-    it("propagates refresh errors to all coalesced callers", async () => {
+    it("waiters retry independently when coalesced refresh fails", async () => {
       const tokenRetriever = new OAuth2ClientCredentials(mockAuth);
 
       mockOAuth.ClientSecretPost.mockReturnValue("mock-client-auth");
@@ -524,7 +524,44 @@ describe("OAuth2ClientCredentials", () => {
       expect(rejected).toHaveLength(5);
       rejected.forEach((r) => expect(r.reason.message).toBe("SSO unavailable"));
 
-      expect(mockOAuth.clientCredentialsGrantRequest).toHaveBeenCalledTimes(1);
+      // Each waiter cascades a retry when the previous refresh fails
+      expect(mockOAuth.clientCredentialsGrantRequest).toHaveBeenCalledTimes(5);
+    });
+
+    it("waiter succeeds when coalesced refresh fails but retry works", async () => {
+      const tokenRetriever = new OAuth2ClientCredentials(mockAuth);
+
+      let callCount = 0;
+      mockOAuth.ClientSecretPost.mockReturnValue("mock-client-auth");
+      mockOAuth.clientCredentialsGrantRequest.mockImplementation(async () => {
+        callCount++;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        if (callCount === 1) {
+          throw new Error("SSO unavailable");
+        }
+        return {};
+      });
+      mockOAuth.processClientCredentialsResponse.mockResolvedValue({
+        access_token: "recovered-token",
+        expires_in: 3600,
+      });
+
+      const promises = Array.from({ length: 5 }, () =>
+        tokenRetriever.getToken(),
+      );
+      const results = await Promise.allSettled(promises);
+
+      const rejected = results.filter((r) => r.status === "rejected");
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+
+      expect(rejected).toHaveLength(1);
+      expect(fulfilled).toHaveLength(4);
+      fulfilled.forEach((r) =>
+        expect((r as PromiseFulfilledResult<any>).value.accessToken).toBe(
+          "recovered-token",
+        ),
+      );
+      expect(callCount).toBe(2);
     });
 
     it("allows retry after a failed coalesced refresh", async () => {

--- a/src/kessel/auth/index.ts
+++ b/src/kessel/auth/index.ts
@@ -161,9 +161,14 @@ export class OAuth2ClientCredentials {
       return this.tokenCache;
     }
 
-    if (this.pendingRefresh) {
-      await this.pendingRefresh;
-      return this.tokenCache;
+    while (this.pendingRefresh) {
+      try {
+        await this.pendingRefresh;
+        return this.tokenCache;
+      } catch {
+        // Another caller's refresh failed. Loop to either coalesce onto a
+        // new in-flight refresh or start our own.
+      }
     }
 
     this.pendingRefresh = this.refresh();

--- a/src/kessel/auth/index.ts
+++ b/src/kessel/auth/index.ts
@@ -84,6 +84,7 @@ export const fetchOIDCDiscovery = async (
  */
 export class OAuth2ClientCredentials {
   private tokenCache?: RefreshTokenResponse;
+  private pendingRefresh: Promise<Readonly<RefreshTokenResponse>> | null = null;
   private authServer: oauth.AuthorizationServer;
   private initialized: boolean = false;
   private ClientSecretPost: typeof oauth.ClientSecretPost;
@@ -145,6 +146,10 @@ export class OAuth2ClientCredentials {
    * 3. Fetch a new token from the OAuth server if needed
    * 4. Cache the new token for future use
    *
+   * Uses Promise coalescing to ensure concurrent callers that all observe a
+   * stale token coalesce into a single OAuth token request, preventing
+   * thundering herd floods against the SSO server.
+   *
    * @param forceRefresh - If true, bypasses cache and forces a new token request
    * @returns A promise that resolves to a RefreshTokenResponse object containing accessToken and expiresAt
    * @throws {Error} If token retrieval fails
@@ -156,8 +161,20 @@ export class OAuth2ClientCredentials {
       return this.tokenCache;
     }
 
-    this.tokenCache = await this.refresh();
-    return this.tokenCache;
+    if (this.pendingRefresh) {
+      await this.pendingRefresh;
+      if (this.isCacheValid()) {
+        return this.tokenCache;
+      }
+    }
+
+    this.pendingRefresh = this.refresh();
+    try {
+      this.tokenCache = await this.pendingRefresh;
+      return this.tokenCache;
+    } finally {
+      this.pendingRefresh = null;
+    }
   }
 
   private async refresh(): Promise<Readonly<RefreshTokenResponse>> {

--- a/src/kessel/auth/index.ts
+++ b/src/kessel/auth/index.ts
@@ -163,9 +163,7 @@ export class OAuth2ClientCredentials {
 
     if (this.pendingRefresh) {
       await this.pendingRefresh;
-      if (this.isCacheValid()) {
-        return this.tokenCache;
-      }
+      return this.tokenCache;
     }
 
     this.pendingRefresh = this.refresh();


### PR DESCRIPTION
- Introduces a way to prevent multiple concurrent calls to SSO
- Aligned with python SDK code paths


https://redhat.atlassian.net/browse/RHCLOUD-47742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified token refresh behavior in performance and security guidelines: concurrent callers share a single in-flight token refresh, errors propagate to all waiters, and subsequent retries behave predictably.

* **Tests**
  * Added comprehensive tests validating concurrent refresh coalescing for normal and forced refreshes, failure propagation to all callers, successful retries, and repeated concurrent batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->