### PR TITLE
RHCLOUD-48471 - Add consistency token support to listWorkspaces()

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ for await (const response of listWorkspaces(
   console.log(response.object?.resourceId);
 }
 
+// With consistency
+for await (const response of listWorkspaces(
+  client,
+  principalSubject("alice", "redhat"),
+  "viewer",
+  { consistency: { minimizeLatency: true } },
+)) {
+  console.log(response.object?.resourceId);
+}
+
 // Materialise into an array
 const all: StreamedListObjectsResponse[] = [];
 for await (const response of listWorkspaces(

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -144,7 +144,14 @@ for await (const response of listWorkspaces(client, principalSubject("alice", "r
 }
 ```
 
-It uses `streamedListObjects` internally with page size 1000 and follows `continuationToken` until exhausted. Accepts an optional initial continuation token for resumption.
+It uses `streamedListObjects` internally with page size 1000 and follows `continuationToken` until exhausted. Accepts an optional initial continuation token for resumption and an optional `Consistency` object to control read freshness:
+
+```typescript
+// With consistency
+for await (const response of listWorkspaces(client, subject, "viewer", undefined, { minimizeLatency: true })) {
+  console.log(response.object?.resourceId);
+}
+```
 
 ## Streaming Responses
 

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -144,11 +144,16 @@ for await (const response of listWorkspaces(client, principalSubject("alice", "r
 }
 ```
 
-It uses `streamedListObjects` internally with page size 1000 and follows `continuationToken` until exhausted. Accepts an optional initial continuation token for resumption and an optional `Consistency` object to control read freshness:
+It uses `streamedListObjects` internally with page size 1000 and follows `continuationToken` until exhausted. The optional fourth argument accepts either a continuation token string (for backward compatibility) or an options object with `continuationToken` and/or `consistency`:
 
 ```typescript
 // With consistency
-for await (const response of listWorkspaces(client, subject, "viewer", undefined, { minimizeLatency: true })) {
+for await (const response of listWorkspaces(client, subject, "viewer", { consistency: { minimizeLatency: true } })) {
+  console.log(response.object?.resourceId);
+}
+
+// With both continuation token and consistency
+for await (const response of listWorkspaces(client, subject, "viewer", { continuationToken: "token", consistency: { minimizeLatency: true } })) {
   console.log(response.object?.resourceId);
 }
 ```

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -73,7 +73,7 @@ for await (const response of stream) {
 For paginated iteration, use the `listWorkspaces` helper from `kessel/rbac/v2` as a reference pattern. It uses `continuationToken` from each response to issue subsequent streamed requests, with a default page limit of 1000. Key points:
 - Stop iterating when `continuationToken` is empty or the stream yields no responses.
 - Each page is a separate gRPC stream call; the helper manages this automatically.
-- Pass an optional `Consistency` object as the fifth parameter to control read freshness.
+- Pass an optional `Consistency` object via the options parameter to control read freshness (e.g. `{ consistency: { minimizeLatency: true } }`).
 
 ## 6. Choose the Right Consistency Level
 

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -73,6 +73,7 @@ for await (const response of stream) {
 For paginated iteration, use the `listWorkspaces` helper from `kessel/rbac/v2` as a reference pattern. It uses `continuationToken` from each response to issue subsequent streamed requests, with a default page limit of 1000. Key points:
 - Stop iterating when `continuationToken` is empty or the stream yields no responses.
 - Each page is a separate gRPC stream call; the helper manages this automatically.
+- Pass an optional `Consistency` object as the fifth parameter to control read freshness.
 
 ## 6. Choose the Right Consistency Level
 

--- a/examples/rbac/list_workspaces.ts
+++ b/examples/rbac/list_workspaces.ts
@@ -27,7 +27,10 @@ import "dotenv/config";
       client,
       principalSubject("alice", "redhat"),
       "view_document",
-      { continuationToken: "foobar_token", consistency: { minimizeLatency: true } },
+      {
+        continuationToken: "foobar_token",
+        consistency: { minimizeLatency: true },
+      },
     )) {
       allWorkspaces.push(response);
     }

--- a/examples/rbac/list_workspaces.ts
+++ b/examples/rbac/list_workspaces.ts
@@ -15,8 +15,7 @@ import "dotenv/config";
       client,
       principalSubject("alice", "redhat"),
       "view_document",
-      undefined,
-      { minimizeLatency: true },
+      "foobar_token",
     )) {
       console.log(`Workspace: ${response.object?.resourceId}`);
     }
@@ -28,8 +27,7 @@ import "dotenv/config";
       client,
       principalSubject("alice", "redhat"),
       "view_document",
-      undefined,
-      { minimizeLatency: true },
+      { continuationToken: "foobar_token", consistency: { minimizeLatency: true } },
     )) {
       allWorkspaces.push(response);
     }

--- a/examples/rbac/list_workspaces.ts
+++ b/examples/rbac/list_workspaces.ts
@@ -15,7 +15,6 @@ import "dotenv/config";
       client,
       principalSubject("alice", "redhat"),
       "view_document",
-      "foobar_token",
     )) {
       console.log(`Workspace: ${response.object?.resourceId}`);
     }
@@ -27,10 +26,7 @@ import "dotenv/config";
       client,
       principalSubject("alice", "redhat"),
       "view_document",
-      {
-        continuationToken: "foobar_token",
-        consistency: { minimizeLatency: true },
-      },
+      { consistency: { minimizeLatency: true } },
     )) {
       allWorkspaces.push(response);
     }

--- a/examples/rbac/list_workspaces.ts
+++ b/examples/rbac/list_workspaces.ts
@@ -15,6 +15,8 @@ import "dotenv/config";
       client,
       principalSubject("alice", "redhat"),
       "view_document",
+      undefined,
+      { minimizeLatency: true },
     )) {
       console.log(`Workspace: ${response.object?.resourceId}`);
     }
@@ -26,6 +28,8 @@ import "dotenv/config";
       client,
       principalSubject("alice", "redhat"),
       "view_document",
+      undefined,
+      { minimizeLatency: true },
     )) {
       allWorkspaces.push(response);
     }

--- a/src/kessel/rbac/__tests__/v2.ts
+++ b/src/kessel/rbac/__tests__/v2.ts
@@ -773,4 +773,89 @@ describe("listWorkspaces", () => {
       expect(client.streamedListObjects).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("consistency", () => {
+    it("passes consistency token to the request", async () => {
+      const consistency = { minimizeLatency: true };
+      const client = createMockInventoryClient(async function* () {
+        yield {
+          object: workspaceResource("workspace-1"),
+          pagination: { continuationToken: "" },
+        };
+      });
+
+      const results: StreamedListObjectsResponse[] = [];
+      for await (const response of listWorkspaces(
+        client,
+        testSubject,
+        "member",
+        undefined,
+        consistency,
+      )) {
+        results.push(response);
+      }
+
+      expect(client.streamedListObjects).toHaveBeenCalledTimes(1);
+      const capturedRequest = client.requests[0];
+      expect(capturedRequest.consistency).toEqual(consistency);
+    });
+
+    it("does not set consistency when undefined", async () => {
+      const client = createMockInventoryClient(async function* () {
+        yield {
+          object: workspaceResource("workspace-1"),
+          pagination: { continuationToken: "" },
+        };
+      });
+
+      const results: StreamedListObjectsResponse[] = [];
+      for await (const response of listWorkspaces(
+        client,
+        testSubject,
+        "member",
+      )) {
+        results.push(response);
+      }
+
+      expect(client.streamedListObjects).toHaveBeenCalledTimes(1);
+      const capturedRequest = client.requests[0];
+      expect(capturedRequest.consistency).toBeUndefined();
+    });
+
+    it("preserves consistency across paginated requests", async () => {
+      const consistency = { minimizeLatency: true };
+      let count = 0;
+      const client = createMockInventoryClient(async function* () {
+        count++;
+        if (count === 1) {
+          yield {
+            object: workspaceResource("workspace-1"),
+            pagination: { continuationToken: "next-page-token" },
+          };
+        } else if (count === 2) {
+          yield {
+            object: workspaceResource("workspace-2"),
+            pagination: { continuationToken: "" },
+          };
+        }
+      });
+
+      const results: StreamedListObjectsResponse[] = [];
+      for await (const response of listWorkspaces(
+        client,
+        testSubject,
+        "member",
+        undefined,
+        consistency,
+      )) {
+        results.push(response);
+      }
+
+      expect(client.streamedListObjects).toHaveBeenCalledTimes(2);
+      const requests = client.requests;
+
+      expect(requests[0].consistency).toEqual(consistency);
+      expect(requests[1].consistency).toEqual(consistency);
+    });
+  });
 });

--- a/src/kessel/rbac/__tests__/v2.ts
+++ b/src/kessel/rbac/__tests__/v2.ts
@@ -775,7 +775,7 @@ describe("listWorkspaces", () => {
   });
 
   describe("consistency", () => {
-    it("passes consistency token to the request", async () => {
+    it("passes consistency via options object", async () => {
       const consistency = { minimizeLatency: true };
       const client = createMockInventoryClient(async function* () {
         yield {
@@ -789,8 +789,7 @@ describe("listWorkspaces", () => {
         client,
         testSubject,
         "member",
-        undefined,
-        consistency,
+        { consistency },
       )) {
         results.push(response);
       }
@@ -845,8 +844,7 @@ describe("listWorkspaces", () => {
         client,
         testSubject,
         "member",
-        undefined,
-        consistency,
+        { consistency },
       )) {
         results.push(response);
       }
@@ -856,6 +854,60 @@ describe("listWorkspaces", () => {
 
       expect(requests[0].consistency).toEqual(consistency);
       expect(requests[1].consistency).toEqual(consistency);
+    });
+
+    it("accepts both continuationToken and consistency in options", async () => {
+      const consistency = { minimizeLatency: true };
+      const client = createMockInventoryClient(async function* () {
+        yield {
+          object: workspaceResource("workspace-1"),
+          pagination: { continuationToken: "" },
+        };
+      });
+
+      const results: StreamedListObjectsResponse[] = [];
+      for await (const response of listWorkspaces(
+        client,
+        testSubject,
+        "member",
+        { continuationToken: "resume-token", consistency: consistency },
+      )) {
+        results.push(response);
+      }
+
+      expect(client.streamedListObjects).toHaveBeenCalledTimes(1);
+      const capturedRequest = client.requests[0];
+      expect(capturedRequest.pagination?.continuationToken).toBe(
+        "resume-token",
+      );
+      expect(capturedRequest.consistency).toEqual(consistency);
+    });
+  });
+
+  describe("backward compatibility", () => {
+    it("accepts a plain string as continuation token", async () => {
+      const client = createMockInventoryClient(async function* () {
+        yield {
+          object: workspaceResource("workspace-1"),
+          pagination: { continuationToken: "" },
+        };
+      });
+
+      const results: StreamedListObjectsResponse[] = [];
+      for await (const response of listWorkspaces(
+        client,
+        testSubject,
+        "member",
+        "legacy-token",
+      )) {
+        results.push(response);
+      }
+
+      expect(client.streamedListObjects).toHaveBeenCalledTimes(1);
+      const capturedRequest = client.requests[0];
+      expect(capturedRequest.pagination?.continuationToken).toBe(
+        "legacy-token",
+      );
     });
   });
 });

--- a/src/kessel/rbac/v2.ts
+++ b/src/kessel/rbac/v2.ts
@@ -149,6 +149,11 @@ export const subject = (
 
 const DEFAULT_PAGE_LIMIT = 1000;
 
+export interface ListWorkspacesOptions {
+  continuationToken?: string;
+  consistency?: Consistency;
+}
+
 /**
  * Lists all workspaces that a subject has a specific relation to.
  *
@@ -159,8 +164,7 @@ const DEFAULT_PAGE_LIMIT = 1000;
  * @param inventory - The inventory service client with a `streamedListObjects` method.
  * @param subject - The subject to check permissions for.
  * @param relation - The relationship type (e.g. "member", "admin", "viewer").
- * @param continuationToken - Optional token to resume listing from a previous position.
- * @param consistency - Optional consistency level for the request.
+ * @param continuationTokenOrOptions - Optional continuation token string or an options object with `continuationToken` and/or `consistency`.
  * @returns An async generator yielding `StreamedListObjectsResponse` objects.
  *
  * @example
@@ -171,7 +175,7 @@ const DEFAULT_PAGE_LIMIT = 1000;
  *
  * @example
  * // With consistency
- * for await (const response of listWorkspaces(client, subject, "viewer", undefined, { minimizeLatency: true })) {
+ * for await (const response of listWorkspaces(client, subject, "viewer", { consistency: { minimizeLatency: true } })) {
  *   console.log(response.object?.resourceId);
  * }
  *
@@ -190,9 +194,15 @@ export async function* listWorkspaces(
   },
   subject: SubjectReference,
   relation: string,
-  continuationToken?: string,
-  consistency?: Consistency,
+  continuationTokenOrOptions?: string | ListWorkspacesOptions,
 ): AsyncGenerator<StreamedListObjectsResponse> {
+  const options =
+    typeof continuationTokenOrOptions === "string"
+      ? { continuationToken: continuationTokenOrOptions }
+      : (continuationTokenOrOptions ?? {});
+  let { continuationToken } = options;
+  const { consistency } = options;
+
   while (true) {
     const request: StreamedListObjectsRequest = {
       objectType: workspaceType(),

--- a/src/kessel/rbac/v2.ts
+++ b/src/kessel/rbac/v2.ts
@@ -170,6 +170,12 @@ const DEFAULT_PAGE_LIMIT = 1000;
  * }
  *
  * @example
+ * // With consistency
+ * for await (const response of listWorkspaces(client, subject, "viewer", undefined, { minimizeLatency: true })) {
+ *   console.log(response.object?.resourceId);
+ * }
+ *
+ * @example
  * // Materialise into an array (eager, all results in memory)
  * const all: StreamedListObjectsResponse[] = [];
  * for await (const response of listWorkspaces(client, subject, "viewer")) {

--- a/src/kessel/rbac/v2.ts
+++ b/src/kessel/rbac/v2.ts
@@ -5,6 +5,7 @@ import { RepresentationType } from "../inventory/v1beta2/representation_type";
 import { ReporterReference } from "../inventory/v1beta2/reporter_reference";
 import { StreamedListObjectsRequest } from "../inventory/v1beta2/streamed_list_objects_request";
 import { StreamedListObjectsResponse } from "../inventory/v1beta2/streamed_list_objects_response";
+import { Consistency } from "../inventory/v1beta2/consistency";
 
 const WORKSPACE_ENDPOINT = "/api/rbac/v2/workspaces/";
 
@@ -159,6 +160,7 @@ const DEFAULT_PAGE_LIMIT = 1000;
  * @param subject - The subject to check permissions for.
  * @param relation - The relationship type (e.g. "member", "admin", "viewer").
  * @param continuationToken - Optional token to resume listing from a previous position.
+ * @param consistency - Optional consistency level for the request.
  * @returns An async generator yielding `StreamedListObjectsResponse` objects.
  *
  * @example
@@ -183,6 +185,7 @@ export async function* listWorkspaces(
   subject: SubjectReference,
   relation: string,
   continuationToken?: string,
+  consistency?: Consistency,
 ): AsyncGenerator<StreamedListObjectsResponse> {
   while (true) {
     const request: StreamedListObjectsRequest = {
@@ -193,6 +196,7 @@ export async function* listWorkspaces(
         limit: DEFAULT_PAGE_LIMIT,
         continuationToken: continuationToken,
       },
+      consistency,
     };
 
     const stream = inventory.streamedListObjects(request);


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-48471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional consistency support to workspace listing. You can now pass a `consistency` object (and optionally a `continuationToken`), which is forwarded on requests and kept consistent across paginated streaming.
* **Documentation**
  * Updated the workspace listing quick start plus integration and performance guidance with new `consistency` examples, including combinations with continuation tokens.
* **Tests**
  * Expanded RBAC test coverage to verify `consistency` propagation/omission, persistence across pagination, and backward compatibility with legacy continuation-token input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->