### PR TITLE
chore: Fix permissions for attestations in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
Didn't realize https://github.com/project-kessel/kessel-sdk-node/actions/runs/29862343291/job/88742256334 didn't finish completely. Release was published on [npm](https://www.npmjs.com/package/@project-kessel/kessel-sdk/v/3.8.0) and [github](https://github.com/project-kessel/kessel-sdk-node/releases/tag/v3.8.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow permissions to support publishing attestations and artifact metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->